### PR TITLE
Refactored code structure to avoid future merge conflicts, renamed route endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ Steps to run:
 
 1. Run `go build` to compile the executable from the file "main.go"
 2. Run the executable named "api" (ex: if using mac run `./api`)
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/csci4950tgt/api
+
+go 1.13
+
+require github.com/gorilla/mux v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/main.go
+++ b/main.go
@@ -5,32 +5,40 @@ import (
 	"fmt"
 	"github.com/gorilla/mux"
 	"net/http"
+	"strconv"
 )
 
 type ScreenShot struct {
-	Width    int64  `json:"width"`
-	Height   int64  `json:"height"`
+	Width    int    `json:"width"`
+	Height   int    `json:"height"`
 	Filename string `json:"filename"`
 }
 
 type Ticket struct {
-	ID         int64      `json:"id"`
+	ID         int        `json:"id"`
 	Name       string     `json:"name"`
 	URL        string     `json:"url"`
 	Screenshot ScreenShot `json:"screenshot"`
 }
 
 func main() {
-	handler := mux.NewRouter()                             // create router for handling api endpoints
-	handler.HandleFunc("/api/create-client", CreateClient) // POST endpoint for creating honeyclient
+	handler := mux.NewRouter()                                       // create router for handling api endpoints
+	handler.HandleFunc("/api/honeyclient/create", CreateHoneyClient) // POST endpoint for creating honeyclient
+	handler.HandleFunc("/api/honeyclient/{id}", GetHoneyClientById)  // GET endpoint for getting honeyclient by id
 	fmt.Println("Server starting on localhost:8080...")
 	http.ListenAndServe(":8080", handler) // listen to requests on localhost:8080
 }
 
-func CreateClient(respond http.ResponseWriter, request *http.Request) {
+func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
 	var ticket Ticket
-	json.NewDecoder(request.Body).Decode(&ticket)
-	ticket.ID, ticket.Name = 1, "Dummy ticket"
-	fmt.Fprintf(respond, "Ticket '%s' (%d) will investigate url '%s' with screenshot dimensions %d x %d", ticket.Name, ticket.ID, ticket.URL, ticket.Screenshot.Width, ticket.Screenshot.Height)
+	json.NewDecoder(r.Body).Decode(&ticket)    // decodes json from request into Ticket struct
+	ticket.ID, ticket.Name = 1, "Dummy ticket" // ID and Name are not part of the request
+	fmt.Fprintf(w, "Ticket '%s' (%d) will investigate url '%s' with screenshot dimensions %d x %d", ticket.Name, ticket.ID, ticket.URL, ticket.Screenshot.Width, ticket.Screenshot.Height)
+}
 
+func GetHoneyClientById(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)               // get dynamic variables from mux handler
+	id, _ := strconv.Atoi(vars["id"]) // get integer "ID" from vars
+	ticket := Ticket{ID: id, Name: "Hardcoded ticket", URL: "https://example.com"}
+	fmt.Fprintf(w, "Fetched ticket '%s' from ID '%d' with URL '%s'", ticket.Name, ticket.ID, ticket.URL)
 }

--- a/main.go
+++ b/main.go
@@ -1,44 +1,16 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/csci4950tgt/api/routes"
 	"github.com/gorilla/mux"
 	"net/http"
-	"strconv"
 )
 
-type ScreenShot struct {
-	Width    int    `json:"width"`
-	Height   int    `json:"height"`
-	Filename string `json:"filename"`
-}
-
-type Ticket struct {
-	ID         int        `json:"id"`
-	Name       string     `json:"name"`
-	URL        string     `json:"url"`
-	Screenshot ScreenShot `json:"screenshot"`
-}
-
 func main() {
-	handler := mux.NewRouter()                                       // create router for handling api endpoints
-	handler.HandleFunc("/api/honeyclient/create", CreateHoneyClient) // POST endpoint for creating honeyclient
-	handler.HandleFunc("/api/honeyclient/{id}", GetHoneyClientById)  // GET endpoint for getting honeyclient by id
+	handler := mux.NewRouter()                                              // create router for handling api endpoints
+	handler.HandleFunc("/api/honeyclient/create", routes.CreateHoneyClient) // POST endpoint for creating honeyclient
+	handler.HandleFunc("/api/honeyclient/{id}", routes.GetHoneyClientById)  // GET endpoint for getting honeyclient by id
 	fmt.Println("Server starting on localhost:8080...")
 	http.ListenAndServe(":8080", handler) // listen to requests on localhost:8080
-}
-
-func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
-	var ticket Ticket
-	json.NewDecoder(r.Body).Decode(&ticket)    // decodes json from request into Ticket struct
-	ticket.ID, ticket.Name = 1, "Dummy ticket" // ID and Name are not part of the request
-	fmt.Fprintf(w, "Ticket '%s' (%d) will investigate url '%s' with screenshot dimensions %d x %d", ticket.Name, ticket.ID, ticket.URL, ticket.Screenshot.Width, ticket.Screenshot.Height)
-}
-
-func GetHoneyClientById(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)               // get dynamic variables from mux handler
-	id, _ := strconv.Atoi(vars["id"]) // get integer "ID" from vars
-	ticket := Ticket{ID: id, Name: "Hardcoded ticket", URL: "https://example.com"}
-	fmt.Fprintf(w, "Fetched ticket '%s' from ID '%d' with URL '%s'", ticket.Name, ticket.ID, ticket.URL)
 }

--- a/models/screenshot.go
+++ b/models/screenshot.go
@@ -1,0 +1,7 @@
+package models
+
+type ScreenShot struct {
+	Width    int    `json:"width"`
+	Height   int    `json:"height"`
+	Filename string `json:"filename"`
+}

--- a/models/ticket.go
+++ b/models/ticket.go
@@ -1,0 +1,8 @@
+package models
+
+type Ticket struct {
+	ID         int        `json:"id"`
+	Name       string     `json:"name"`
+	URL        string     `json:"url"`
+	Screenshot ScreenShot `json:"screenshot"`
+}

--- a/routes/create_honey_client.go
+++ b/routes/create_honey_client.go
@@ -1,0 +1,15 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/csci4950tgt/api/models"
+	"net/http"
+)
+
+func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
+	var ticket models.Ticket
+	json.NewDecoder(r.Body).Decode(&ticket)    // decodes json from request into Ticket struct
+	ticket.ID, ticket.Name = 1, "Dummy ticket" // ID and Name are not part of the request
+	fmt.Fprintf(w, "Ticket '%s' (%d) will investigate url '%s' with screenshot dimensions %d x %d", ticket.Name, ticket.ID, ticket.URL, ticket.Screenshot.Width, ticket.Screenshot.Height)
+}

--- a/routes/get_honey_client_by_id.go
+++ b/routes/get_honey_client_by_id.go
@@ -1,0 +1,16 @@
+package routes
+
+import (
+	"fmt"
+	"github.com/csci4950tgt/api/models"
+	"github.com/gorilla/mux"
+	"net/http"
+	"strconv"
+)
+
+func GetHoneyClientById(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)               // get dynamic variables from mux handler
+	id, _ := strconv.Atoi(vars["id"]) // get integer "ID" from vars
+	ticket := models.Ticket{ID: id, Name: "Hardcoded ticket", URL: "https://example.com"}
+	fmt.Fprintf(w, "Fetched ticket '%s' from ID '%d' with URL '%s'", ticket.Name, ticket.ID, ticket.URL)
+}


### PR DESCRIPTION
First commit:
* added a dynamic GET endpoint for getting a honeyclient at `/api/honeyclient/{id}`
* refactored POST endpoint for creating honeyclient from `/api/create-client` to `/api/honeyclient/create` (thought it looked nicer with the GET endpoint)

Second commit:
* Refactored `Ticket` and `Screenshot` structs into their own files inside the `/models` directory
* Refactored the `CreateHoneyClient` and `GetHoneyClientById` endpoint functions into the `routes/` directory.
* Deleted these structs and functions from the `main.go` file and imported them
* initialized a `go.mod` file to make the `api` directory a module and allow imports to work (this auto-generates a go.sum file, and apparently we should keep them both in vc)