### PR TITLE
fix(http): cors header name

### DIFF
--- a/routes/create_honey_client.go
+++ b/routes/create_honey_client.go
@@ -10,7 +10,7 @@ import (
 
 func SetupCreateResponse(w *http.ResponseWriter, r *http.Request) {
 	(*w).Header().Set("Access-Control-Allow-Origin", "*")
-	(*w).Header().Set("Access-Control-Allow-Methos", "POST")
+	(*w).Header().Set("Access-Control-Allow-Method", "POST")
 }
 
 func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {

--- a/routes/get_honey_client_by_id.go
+++ b/routes/get_honey_client_by_id.go
@@ -10,7 +10,7 @@ import (
 
 func SetupGetResponse(w *http.ResponseWriter, r *http.Request) {
 	(*w).Header().Set("Access-Control-Allow-Origin", "*")
-	(*w).Header().Set("Access-Control-Allow-Methos", "GET")
+	(*w).Header().Set("Access-Control-Allow-Method", "GET")
 }
 
 func GetHoneyClientById(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes a typo in the CORS header name, preventing it from being respected on the client.

Regression introduced in https://github.com/csci4950tgt/api/pull/16/commits/6dcfe50453521bd7bc9bbd075b319431c1ca4e70 and merged in #16.