### PR TITLE
refactor(http): format responses as JSON

### DIFF
--- a/models/response.go
+++ b/models/response.go
@@ -1,0 +1,17 @@
+package models
+
+type ResponseError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type Response struct {
+	Success bool           `json:"success"`
+	Error   *ResponseError `json:"error,omitempty"`
+	Message *string        `json:"message,omitempty"`
+}
+
+// Makes ResponseError satisfy builtin Error type. See: https://blog.golang.org/error-handling-and-go
+func (e *ResponseError) Error() string {
+	return e.Message
+}

--- a/models/response.go
+++ b/models/response.go
@@ -1,5 +1,10 @@
 package models
 
+type ResponseHeader struct {
+	Key   string
+	Value string
+}
+
 type ResponseError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`

--- a/models/response.go
+++ b/models/response.go
@@ -1,10 +1,5 @@
 package models
 
-type ResponseHeader struct {
-	Key   string
-	Value string
-}
-
 type ResponseError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`

--- a/routes/create_honey_client.go
+++ b/routes/create_honey_client.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/csci4950tgt/api/models"
-	"net/http"
+	"github.com/csci4950tgt/api/util"
 	"io/ioutil"
+	"net/http"
 )
 
 func SetupCreateResponse(w *http.ResponseWriter, r *http.Request) {
@@ -19,8 +20,8 @@ func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
 	SetupCreateResponse(&w, r)
 	// If request type is not current request, return error.
 	if (*r).Method != "POST" {
-		w.WriteHeader(405)
-		fmt.Fprintf(w, "Method \"%s\" is not allowed.\n",(*r).Method)
+		util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, fmt.Sprintf("Method \"%s\" is not allowed.\n", (*r).Method))
+
 		return
 	}
 
@@ -37,11 +38,23 @@ func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
 	file_name := fmt.Sprintf("../honeyclient/input/%d.json", ticket.ID)
 	file, _ := json.MarshalIndent(ticket, "", " ")
 	err := ioutil.WriteFile(file_name, file, 0755)
+
 	if err != nil {
-		w.WriteHeader(500)
-		fmt.Fprintf(w, "Error happens in connecting honeyclient. %s.\n",
-					err.Error())
-	} else {
-		fmt.Fprintf(w, "Create ticket '%s' with ID '%d' and URL '%s'", ticket.Name, ticket.ID, ticket.URL)
+		util.WriteHttpErrorCode(w, http.StatusInternalServerError, "Failed to write file for honeyclient to consume.")
+
+		fmt.Println("Failed to write file for honeyclient to consume:")
+		fmt.Println(err)
+
+		return
 	}
+
+	// TODO: run honeyclient and return error if failed
+
+	msg := fmt.Sprintf("Create ticket '%s' with ID '%d' and URL '%s'", ticket.Name, ticket.ID, ticket.URL)
+	res := models.Response{
+		Success: true,
+		Message: &msg,
+	}
+
+	util.WriteHttpResponse(w, res)
 }

--- a/routes/create_honey_client.go
+++ b/routes/create_honey_client.go
@@ -18,25 +18,16 @@ func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Initialize headers array
-	headers := []models.ResponseHeader{
-		models.ResponseHeader{
-			Key:   "Access-Control-Allow-Origin",
-			Value: "*",
-		},
-		models.ResponseHeader{
-			Key:   "Access-Control-Allow-Methods",
-			Value: "POST",
-		},
-	}
+	// Initialize header
+	header := http.Header{}
+	header.Add("Access-Control-Allow-Origin", "*")
+	header.Add("Access-Control-Allow-Methods", "POST")
 
-	// Set headers
-	util.SetHeaders(w, headers)
+	// Set header
+	util.SetHeader(w, header)
 
-	// Create a new ticket for handling
+	// Create a new ticket for handling, encode request into struct
 	var ticket models.Ticket
-
-	// Decodes json from request into Ticket struct
 	json.NewDecoder(r.Body).Decode(&ticket)
 	ticket.ID = 1
 

--- a/routes/create_honey_client.go
+++ b/routes/create_honey_client.go
@@ -9,29 +9,35 @@ import (
 	"net/http"
 )
 
-func SetupCreateResponse(w *http.ResponseWriter, r *http.Request) {
-	(*w).Header().Set("Access-Control-Allow-Origin", "*")
-	(*w).Header().Set("Access-Control-Allow-Methos", "POST")
-}
-
 func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
-
-	// Handling requests.
-	SetupCreateResponse(&w, r)
 	// If request type is not current request, return error.
 	if (*r).Method != "POST" {
-		util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, fmt.Sprintf("Method \"%s\" is not allowed.\n", (*r).Method))
+		msg := fmt.Sprintf("Method \"%s\" is not allowed.", (*r).Method)
+		util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, msg)
 
 		return
 	}
 
+	// Initialize headers array
+	headers := []models.ResponseHeader{
+		models.ResponseHeader{
+			Key:   "Access-Control-Allow-Origin",
+			Value: "*",
+		},
+		models.ResponseHeader{
+			Key:   "Access-Control-Allow-Methods",
+			Value: "POST",
+		},
+	}
+
+	// Set headers
+	util.SetHeaders(w, headers)
+
 	// Create a new ticket for handling
 	var ticket models.Ticket
 
-	// decodes json from request into Ticket struct
+	// Decodes json from request into Ticket struct
 	json.NewDecoder(r.Body).Decode(&ticket)
-
-	// ID and Name are not part of the request
 	ticket.ID = 1
 
 	// Create and write to json file
@@ -50,6 +56,7 @@ func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
 
 	// TODO: run honeyclient and return error if failed
 
+	// Initialize Response
 	msg := fmt.Sprintf("Create ticket '%s' with ID '%d' and URL '%s'", ticket.Name, ticket.ID, ticket.URL)
 	res := models.Response{
 		Success: true,

--- a/routes/get_honey_client_by_id.go
+++ b/routes/get_honey_client_by_id.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"fmt"
 	"github.com/csci4950tgt/api/models"
+	"github.com/csci4950tgt/api/util"
 	"github.com/gorilla/mux"
 	"net/http"
 	"strconv"
@@ -19,13 +20,20 @@ func GetHoneyClientById(w http.ResponseWriter, r *http.Request) {
 	SetupGetResponse(&w, r)
 	// If request type is not current request, return error.
 	if (*r).Method != "GET" {
-		w.WriteHeader(405)
-		fmt.Fprintf(w, "Method \"%s\" is not allowed.\n",(*r).Method)
+		util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, fmt.Sprintf("Method \"%s\" is not allowed.\n", (*r).Method))
+
 		return
 	}
 
 	vars := mux.Vars(r)               // get dynamic variables from mux handler
 	id, _ := strconv.Atoi(vars["id"]) // get integer "ID" from vars
 	ticket := models.Ticket{ID: id, Name: "Hardcoded ticket", URL: "https://example.com"}
-	fmt.Fprintf(w, "Fetched ticket '%s' from ID '%d' with URL '%s'", ticket.Name, ticket.ID, ticket.URL)
+
+	msg := fmt.Sprintf("Fetched ticket '%s' from ID '%d' with URL '%s'", ticket.Name, ticket.ID, ticket.URL)
+	res := models.Response{
+		Success: true,
+		Message: &msg,
+	}
+
+	util.WriteHttpResponse(w, res)
 }

--- a/routes/get_honey_client_by_id.go
+++ b/routes/get_honey_client_by_id.go
@@ -18,20 +18,13 @@ func GetHoneyClientById(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Initialize headers array
-	headers := []models.ResponseHeader{
-		models.ResponseHeader{
-			Key:   "Access-Control-Allow-Origin",
-			Value: "*",
-		},
-		models.ResponseHeader{
-			Key:   "Access-Control-Allow-Methods",
-			Value: "GET",
-		},
-	}
+	// Initialize header
+	header := http.Header{}
+	header.Add("Access-Control-Allow-Origin", "*")
+	header.Add("Access-Control-Allow-Methods", "GET")
 
-	// Set headers
-	util.SetHeaders(w, headers)
+	// Set header
+	util.SetHeader(w, header)
 
 	// Initialize Ticket struct
 	vars := mux.Vars(r)               // get dynamic variables from mux handler

--- a/routes/get_honey_client_by_id.go
+++ b/routes/get_honey_client_by_id.go
@@ -9,26 +9,36 @@ import (
 	"strconv"
 )
 
-func SetupGetResponse(w *http.ResponseWriter, r *http.Request) {
-	(*w).Header().Set("Access-Control-Allow-Origin", "*")
-	(*w).Header().Set("Access-Control-Allow-Methos", "GET")
-}
-
 func GetHoneyClientById(w http.ResponseWriter, r *http.Request) {
-
-	// Handling requests.
-	SetupGetResponse(&w, r)
 	// If request type is not current request, return error.
 	if (*r).Method != "GET" {
-		util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, fmt.Sprintf("Method \"%s\" is not allowed.\n", (*r).Method))
+		msg := fmt.Sprintf("Method \"%s\" is not allowed.", (*r).Method)
+		util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, msg)
 
 		return
 	}
 
+	// Initialize headers array
+	headers := []models.ResponseHeader{
+		models.ResponseHeader{
+			Key:   "Access-Control-Allow-Origin",
+			Value: "*",
+		},
+		models.ResponseHeader{
+			Key:   "Access-Control-Allow-Methods",
+			Value: "GET",
+		},
+	}
+
+	// Set headers
+	util.SetHeaders(w, headers)
+
+	// Initialize Ticket struct
 	vars := mux.Vars(r)               // get dynamic variables from mux handler
 	id, _ := strconv.Atoi(vars["id"]) // get integer "ID" from vars
 	ticket := models.Ticket{ID: id, Name: "Hardcoded ticket", URL: "https://example.com"}
 
+	// Initialize Response
 	msg := fmt.Sprintf("Fetched ticket '%s' from ID '%d' with URL '%s'", ticket.Name, ticket.ID, ticket.URL)
 	res := models.Response{
 		Success: true,

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"encoding/json"
+	"github.com/csci4950tgt/api/models"
+	"net/http"
+)
+
+// Encodes a `models.Response` object as JSON, handling errors in writing
+// or sending it to the HTTP output stream.
+func WriteHttpResponse(w http.ResponseWriter, res models.Response) {
+	js, err := json.Marshal(res)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
+func WriteHttpError(w http.ResponseWriter, err models.ResponseError) {
+	w.WriteHeader(err.Code)
+
+	res := models.Response{
+		Success: false,
+		Error:   &err,
+	}
+
+	WriteHttpResponse(w, res)
+}
+
+func WriteHttpErrorCode(w http.ResponseWriter, code int, message string) {
+	err := models.ResponseError{
+		Code:    code,
+		Message: message,
+	}
+
+	WriteHttpError(w, err)
+}
+
+// Return 200 OK, `{"success": true}`
+func WriteHttpEmptySuccess(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusOK)
+
+	res := models.Response{
+		Success: true,
+	}
+
+	WriteHttpResponse(w, res)
+}

--- a/util/util.go
+++ b/util/util.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 )
 
-// Set multiple headers by looping through header array
-func SetHeaders(w http.ResponseWriter, headers []models.ResponseHeader) {
-	for _, header := range headers {
-		w.Header().Set(header.Key, header.Value)
+// Set all key, value pairs of header in response
+func SetHeader(w http.ResponseWriter, header http.Header) {
+	for k, _ := range header {
+		w.Header().Set(k, header.Get(k))
 	}
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -6,6 +6,13 @@ import (
 	"net/http"
 )
 
+// Set multiple headers by looping through header array
+func SetHeaders(w http.ResponseWriter, headers []models.ResponseHeader) {
+	for _, header := range headers {
+		w.Header().Set(header.Key, header.Value)
+	}
+}
+
 // Encodes a `models.Response` object as JSON, handling errors in writing
 // or sending it to the HTTP output stream.
 func WriteHttpResponse(w http.ResponseWriter, res models.Response) {


### PR DESCRIPTION
Creates a response model to return the result of an endpoint's execution to the client in a JSON-compliant format. **This is a contract-breaking API change.**

The client can now parse the output's success field to see if it can continue with the next action. If not successful, an error object can be returned with an error code and message. This allows for application-specific error codes that don't fit nicely into the HTTP status codes, or provide more information (e.g. failed to start the honey client).

- Adopts a convention of using exports from `http` for status codes, for improved readability.
- Changed the "[...] connecting honeyclient" error to reflect the `err` scenario, namely that the file couldn't be written.
- No longer returns the system error to the client if writing the file fails - this is a bad practice, as it can open security holes, or expose information to the user they shouldn't see. Instead, returns an error message and code, and logs the system error to the console.

Sample output:
```
➜  api git:(refactor/http-response-fmt) ✗ curl localhost:8080/api/honeyclient/create        
{"success":false,"error":{"code":405,"message":"Method \"GET\" is not allowed.\n"}}

➜  api git:(refactor/http-response-fmt) ✗ curl -X POST localhost:8080/api/honeyclient/create
{"success":false,"error":{"code":500,"message":"Failed to write file for honeyclient to consume."}}

➜  api git:(refactor/http-response-fmt) ✗ mkdir ../honeyclient; mkdir ../honeyclient/input  

➜  api git:(refactor/http-response-fmt) ✗ curl -X POST localhost:8080/api/honeyclient/create
{"success":true,"message":"Create ticket '' with ID '1' and URL ''"}   
```