### PR TITLE
Changed routes to new routes specified in doc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/csci4950tgt/api
 go 1.13
 
 require (
+	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/jinzhu/gorm v1.9.11
 	github.com/lib/pq v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
+github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/main.go
+++ b/main.go
@@ -29,6 +29,6 @@ func main() {
 
 	// Listen and serve baby
 	fmt.Println("Server starting...")
-	allowedOrigins := handlers.AllowedOrigins([]string{"http://localhost:3000, http://localhost:8000"})
+	allowedOrigins := handlers.AllowedOrigins([]string{"http://localhost:3000", "http://localhost:5000"})
 	http.ListenAndServe(":8080", handlers.CORS(allowedOrigins)(r))
 }

--- a/main.go
+++ b/main.go
@@ -6,16 +6,29 @@ import (
 
 	"github.com/csci4950tgt/api/models"
 	"github.com/csci4950tgt/api/routes"
+	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 )
 
-func main() {
-	handler := mux.NewRouter()                                              // create router for handling api endpoints
-	handler.HandleFunc("/api/honeyclient/create", routes.CreateHoneyClient) // POST endpoint for creating honeyclient
-	handler.HandleFunc("/api/honeyclient/{id}", routes.GetHoneyClientById)  // GET endpoint for getting honeyclient by id
+// Handles API routes for mux router
+func handleRoutes(r *mux.Router) {
+	r.HandleFunc("/api/tickets", routes.GetTickets).Methods("GET")
+	r.HandleFunc("/api/tickets", routes.CreateTicket).Methods("POST")
+	r.HandleFunc("/api/tickets/{id}", routes.GetTicket).Methods("GET")
+	r.HandleFunc("/api/tickets/{id}/artifacts", routes.GetTicketArtifacts).Methods("GET")
+	r.HandleFunc("/api/tickets/{id}/artifacts/{artifact}", routes.GetTicketArtifact).Methods("GET")
+}
 
+func main() {
+	// Initialize router
+	r := mux.NewRouter()
+	handleRoutes(r)
+
+	// Initialize DB
 	models.InitDB("host=127.0.0.1 port=5432 user=gorm dbname=gorm password=gorm sslmode=disable")
 
+	// Listen and serve baby
 	fmt.Println("Server starting...")
-	http.ListenAndServe(":8080", handler) // listen to requests on localhost:8080
+	allowedOrigins := handlers.AllowedOrigins([]string{"http://localhost:3000, http://localhost:8000"})
+	http.ListenAndServe(":8080", handlers.CORS(allowedOrigins)(r))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -18,20 +18,23 @@ func TestConnection(t *testing.T) {
 	}
 }
 
-func TestCreateClient(t *testing.T) {
+func TestCreateTicket(t *testing.T) {
 	go main()
 	time.Sleep(1 * time.Second)
-	url := "http://127.0.0.1:8080/api/honeyclient/create"
+	url := "http://127.0.0.1:8080/api/tickets"
+
+	// Test that GET method works
 	resp, err := http.Get(url)
 	if err != nil {
 		t.Error(err)
 	}
 
 	statusCode := resp.StatusCode
-	if statusCode != http.StatusMethodNotAllowed {
-		t.Error("Expected http status code: 405, actual code: " + resp.Status)
+	if statusCode != http.StatusOK {
+		t.Error("HTTP error, reason " + resp.Status)
 	}
 
+	// Test that POST method works
 	request := &models.Ticket{URL: "https://www.google.com", ScreenShot: []models.ScreenShot{models.ScreenShot{Width: 1920, Height: 1080, Filename: "screenshot.png"}}}
 	requestJson, err := json.Marshal(request)
 	if err != nil {
@@ -43,12 +46,25 @@ func TestCreateClient(t *testing.T) {
 	if statusCode != http.StatusOK {
 		t.Error("HTTP error, reason " + resp.Status)
 	}
+
+	// Test invalid method - DELETE
+	client := &http.Client{}
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	resp, err = client.Do(req)
+	statusCode = resp.StatusCode
+	if statusCode != http.StatusMethodNotAllowed {
+		t.Error("Expected http status code: 405, actual code: " + resp.Status)
+	}
 }
 
-func TestGetHoneyClientById(t *testing.T) {
+func TestGetTicket(t *testing.T) {
 	go main()
 	time.Sleep(1 * time.Second)
-	resp, err := http.Get("http://127.0.0.1:8080/api/honeyclient/2000000")
+	resp, err := http.Get("http://127.0.0.1:8080/tickets/2000000")
 	if err != nil {
 		t.Error(err)
 	}

--- a/routes/create_ticket.go
+++ b/routes/create_ticket.go
@@ -9,23 +9,7 @@ import (
 	"github.com/csci4950tgt/api/util"
 )
 
-func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
-	// If request type is not current request, return error.
-	if (*r).Method != "POST" {
-		msg := fmt.Sprintf("Method \"%s\" is not allowed.", (*r).Method)
-		util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, msg)
-
-		return
-	}
-
-	// Initialize header
-	header := http.Header{}
-	header.Add("Access-Control-Allow-Origin", "*")
-	header.Add("Access-Control-Allow-Methods", "POST")
-
-	// Set header
-	util.SetHeader(w, header)
-
+func CreateTicket(w http.ResponseWriter, r *http.Request) {
 	// Create a new ticket for handling, encode request into struct
 	var ticket models.Ticket
 
@@ -37,10 +21,8 @@ func CreateHoneyClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// mark new ticket for processing:
+	// mark new ticket for processing and save in db:
 	ticket.Processed = false
-
-	// saves the ticket in the database:
 	err = models.CreateTicket(&ticket)
 
 	if err != nil {

--- a/routes/get_ticket.go
+++ b/routes/get_ticket.go
@@ -12,8 +12,8 @@ import (
 
 func GetTicket(w http.ResponseWriter, r *http.Request) {
 	// Get variables from router
-	vars := mux.Vars(r)                 // get dynamic variables from mux handler
-	id, err := strconv.Atoi(vars["id"]) // get integer "ID" from var
+	vars := mux.Vars(r)                       // get dynamic variables from mux handler
+	ticketId, err := strconv.Atoi(vars["id"]) // get integer "ID" from var
 
 	if err != nil {
 		util.WriteHttpErrorCode(w, http.StatusBadRequest, "Missing required parameter: id.")
@@ -21,10 +21,10 @@ func GetTicket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ticket, err := models.GetTicketById(uint(id))
+	ticket, err := models.GetTicketById(uint(ticketId))
 
 	if err != nil {
-		msg := fmt.Sprintf("Failed to find ticket with ID %d.", id)
+		msg := fmt.Sprintf("Failed to find ticket with ID %d.", ticketId)
 		util.WriteHttpErrorCode(w, http.StatusNotFound, msg)
 
 		return

--- a/routes/get_ticket.go
+++ b/routes/get_ticket.go
@@ -10,24 +10,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func GetHoneyClientById(w http.ResponseWriter, r *http.Request) {
-	// If request type is not current request, return error.
-	if (*r).Method != "GET" {
-		msg := fmt.Sprintf("Method \"%s\" is not allowed.", (*r).Method)
-		util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, msg)
-
-		return
-	}
-
-	// Initialize header
-	header := http.Header{}
-	header.Add("Access-Control-Allow-Origin", "*")
-	header.Add("Access-Control-Allow-Methods", "GET")
-
-	// Set header
-	util.SetHeader(w, header)
-
-	// Initialize Ticket struct
+func GetTicket(w http.ResponseWriter, r *http.Request) {
+	// Get variables from router
 	vars := mux.Vars(r)                 // get dynamic variables from mux handler
 	id, err := strconv.Atoi(vars["id"]) // get integer "ID" from var
 

--- a/routes/get_ticket_artifact.go
+++ b/routes/get_ticket_artifact.go
@@ -1,0 +1,36 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/csci4950tgt/api/models"
+	"github.com/csci4950tgt/api/util"
+	"github.com/gorilla/mux"
+)
+
+func GetTicketArtifact(w http.ResponseWriter, r *http.Request) {
+	// Get variables from route handler
+	vars := mux.Vars(r) // get dynamic variables from mux handler
+	artifact := vars["artifact"]
+	id, err := strconv.Atoi(vars["id"]) // get integer "id" from vars
+
+	if err != nil {
+		util.WriteHttpErrorCode(w, http.StatusBadRequest, "Missing required parameter: id.")
+
+		return
+	}
+
+	// TODO: Actually get desired artifact from ticket
+
+	// Initialize Response
+	msg := fmt.Sprintf("Not yet implemented... Id: %d, Artifact: %s", id, artifact)
+	res := models.Response{
+		Success: true,
+		Message: &msg,
+		// TODO: Send artifact in response
+	}
+
+	util.WriteHttpResponse(w, res)
+}

--- a/routes/get_ticket_artifact.go
+++ b/routes/get_ticket_artifact.go
@@ -14,7 +14,7 @@ func GetTicketArtifact(w http.ResponseWriter, r *http.Request) {
 	// Get variables from route handler
 	vars := mux.Vars(r) // get dynamic variables from mux handler
 	artifact := vars["artifact"]
-	id, err := strconv.Atoi(vars["id"]) // get integer "id" from vars
+	ticketId, err := strconv.Atoi(vars["id"]) // get integer "id" from vars
 
 	if err != nil {
 		util.WriteHttpErrorCode(w, http.StatusBadRequest, "Missing required parameter: id.")
@@ -25,7 +25,7 @@ func GetTicketArtifact(w http.ResponseWriter, r *http.Request) {
 	// TODO: Actually get desired artifact from ticket
 
 	// Initialize Response
-	msg := fmt.Sprintf("Not yet implemented... Id: %d, Artifact: %s", id, artifact)
+	msg := fmt.Sprintf("Not yet implemented... ticketId: %d, Artifact: %s", ticketId, artifact)
 	res := models.Response{
 		Success: true,
 		Message: &msg,

--- a/routes/get_ticket_artifacts.go
+++ b/routes/get_ticket_artifacts.go
@@ -12,8 +12,8 @@ import (
 
 func GetTicketArtifacts(w http.ResponseWriter, r *http.Request) {
 	// Get variables from route handler
-	vars := mux.Vars(r)                 // get dynamic variables from mux handler
-	id, err := strconv.Atoi(vars["id"]) // get integer "id" from vars
+	vars := mux.Vars(r)                       // get dynamic variables from mux handler
+	ticketId, err := strconv.Atoi(vars["id"]) // get integer "id" from vars
 
 	if err != nil {
 		util.WriteHttpErrorCode(w, http.StatusBadRequest, "Missing required parameter: id.")
@@ -24,7 +24,7 @@ func GetTicketArtifacts(w http.ResponseWriter, r *http.Request) {
 	// TODO: Get artifacts for ticket from database
 
 	// Initialize Response
-	msg := fmt.Sprintf("Not yet implemented... Id: %d", id)
+	msg := fmt.Sprintf("Not yet implemented... ticketId: %d", ticketId)
 	res := models.Response{
 		Success: true,
 		Message: &msg,

--- a/routes/get_ticket_artifacts.go
+++ b/routes/get_ticket_artifacts.go
@@ -1,0 +1,35 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/csci4950tgt/api/models"
+	"github.com/csci4950tgt/api/util"
+	"github.com/gorilla/mux"
+)
+
+func GetTicketArtifacts(w http.ResponseWriter, r *http.Request) {
+	// Get variables from route handler
+	vars := mux.Vars(r)                 // get dynamic variables from mux handler
+	id, err := strconv.Atoi(vars["id"]) // get integer "id" from vars
+
+	if err != nil {
+		util.WriteHttpErrorCode(w, http.StatusBadRequest, "Missing required parameter: id.")
+
+		return
+	}
+
+	// TODO: Get artifacts for ticket from database
+
+	// Initialize Response
+	msg := fmt.Sprintf("Not yet implemented... Id: %d", id)
+	res := models.Response{
+		Success: true,
+		Message: &msg,
+		// TODO: add artifacts data to response
+	}
+
+	util.WriteHttpResponse(w, res)
+}

--- a/routes/get_tickets.go
+++ b/routes/get_tickets.go
@@ -1,0 +1,42 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/csci4950tgt/api/models"
+	"github.com/csci4950tgt/api/util"
+	"github.com/gorilla/mux"
+)
+
+func MethodNotAllowedHelper(w http.ResponseWriter, r *http.Request) {
+	msg := fmt.Sprintf("Method \"%s\" is not allowed.", (*r).Method)
+	util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, msg)
+}
+
+func GetTickets(w http.ResponseWriter, r *http.Request) {
+	// If request type is not current request, return error.
+	if (*r).Method != "GET" {
+		MethodNotAllowedHelper(w, r)
+		return
+	}
+
+	// Initialize header
+	header := http.Header{}
+	header.Add("Access-Control-Allow-Origin", "*")
+	header.Add("Access-Control-Allow-Methods", "GET")
+
+	// Set header
+	util.SetHeader(w, header)
+
+	// TODO: Actually get all tickets
+
+	// Initialize Response
+	res := models.Response{
+		Success: true,
+		// TODO: Return tickets in response
+	}
+
+	util.WriteHttpResponse(w, res)
+}

--- a/routes/get_tickets.go
+++ b/routes/get_tickets.go
@@ -1,40 +1,20 @@
 package routes
 
 import (
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/csci4950tgt/api/models"
 	"github.com/csci4950tgt/api/util"
-	"github.com/gorilla/mux"
 )
 
-func MethodNotAllowedHelper(w http.ResponseWriter, r *http.Request) {
-	msg := fmt.Sprintf("Method \"%s\" is not allowed.", (*r).Method)
-	util.WriteHttpErrorCode(w, http.StatusMethodNotAllowed, msg)
-}
-
 func GetTickets(w http.ResponseWriter, r *http.Request) {
-	// If request type is not current request, return error.
-	if (*r).Method != "GET" {
-		MethodNotAllowedHelper(w, r)
-		return
-	}
-
-	// Initialize header
-	header := http.Header{}
-	header.Add("Access-Control-Allow-Origin", "*")
-	header.Add("Access-Control-Allow-Methods", "GET")
-
-	// Set header
-	util.SetHeader(w, header)
-
 	// TODO: Actually get all tickets
 
 	// Initialize Response
+	msg := "Not yet implemented!!"
 	res := models.Response{
 		Success: true,
+		Message: &msg,
 		// TODO: Return tickets in response
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -15,11 +15,15 @@ func WriteHttpResponse(w http.ResponseWriter, res models.Response) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	// header already set if error, need to set on success
+	if res.Success {
+		w.Header().Set("Content-Type", "application/json")
+	}
 	w.Write(js)
 }
 
 func WriteHttpError(w http.ResponseWriter, err models.ResponseError) {
+	w.Header().Set("Content-Type", "application/json") // need to set before WriteHeader() otherwise won't be processed
 	w.WriteHeader(err.Code)
 
 	res := models.Response{

--- a/util/util.go
+++ b/util/util.go
@@ -6,13 +6,6 @@ import (
 	"net/http"
 )
 
-// Set all key, value pairs of header in response
-func SetHeader(w http.ResponseWriter, header http.Header) {
-	for k, _ := range header {
-		w.Header().Set(k, header.Get(k))
-	}
-}
-
 // Encodes a `models.Response` object as JSON, handling errors in writing
 // or sending it to the HTTP output stream.
 func WriteHttpResponse(w http.ResponseWriter, res models.Response) {


### PR DESCRIPTION
**Should not be merged into master until Frontend has PR with updated route calls** #32 

Routes supported after this PR:

- GET /api/tickets (get all tickets)
- POST /api/tickets (creates a ticket)
- GET /api/tickets/{id} (get all information associated with a specific ticket)
- GET /api/tickets/{id}/artifacts (get an array of all file artifacts names like screenshots or js associated with specific ticket)
- GET /api/tickets/{id}/artifacts/{artifact} (get specific artifact associated with a ticket)

Other notes:

- POST /api/tickets has full functionality in creating a ticket
- GET /api/tickets/{id} has full functionality in getting information about a ticket
- all other endpoints still need to be implemented.