### PR TITLE
feat(routes.artifacts): implement artifact listing and download endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func handleRoutes(r *mux.Router) {
 	r.HandleFunc("/api/tickets", routes.CreateTicket).Methods("POST")
 	r.HandleFunc("/api/tickets/{id}", routes.GetTicket).Methods("GET")
 	r.HandleFunc("/api/tickets/{id}/artifacts", routes.GetTicketArtifacts).Methods("GET")
+	r.HandleFunc("/api/tickets/{id}/artifacts/{fileName}", routes.GetArtifact).Methods("GET")
 	r.HandleFunc("/api/tickets/{id}/artifacts/screenshots", routes.GetTicketScreenshots).Methods("GET")
 	// TODO: make following route work
 	// r.HandleFunc("/api/tickets/{id}/artifacts/js", routes.GetTicketJS).Methods("GET")

--- a/models/file_artifact.go
+++ b/models/file_artifact.go
@@ -9,7 +9,15 @@ type FileArtifact struct {
 func GetAssociatedArtifacts(TicketID uint) (*[]FileArtifact, error) {
 	var fileArtifacts []FileArtifact
 
-	err := db.Where("ticket_id = ?", TicketID).Find(&fileArtifacts, TicketID).Error
+	err := db.Where("ticket_id = ?", TicketID).Find(&fileArtifacts).Error
 
 	return &fileArtifacts, err
+}
+
+func GetArtifact(TicketID uint, FileName string) (*FileArtifact, error) {
+	var fileArtifact FileArtifact
+
+	err := db.Where("ticket_id = ? AND filename = ?", TicketID, FileName).First(&fileArtifact).Error
+
+	return &fileArtifact, err
 }

--- a/models/file_artifact.go
+++ b/models/file_artifact.go
@@ -3,5 +3,13 @@ package models
 type FileArtifact struct {
 	TicketId uint   `json:"ticketID" gorm:"primary_key"`
 	Filename string `json:"filename" gorm:"primary_key"`
-	Data     []byte
+	Data     []byte `json:"-"`
+}
+
+func GetAssociatedArtifacts(TicketID uint) (*[]FileArtifact, error) {
+	var fileArtifacts []FileArtifact
+
+	err := db.Where("ticket_id = ?", TicketID).Find(&fileArtifacts, TicketID).Error
+
+	return &fileArtifacts, err
 }

--- a/models/response.go
+++ b/models/response.go
@@ -6,10 +6,11 @@ type ResponseError struct {
 }
 
 type Response struct {
-	Success bool           `json:"success"`
-	Error   *ResponseError `json:"error,omitempty"`
-	Message *string        `json:"message,omitempty"`
-	Ticket  *Ticket        `json:"ticket,omitempty"`
+	Success       bool            `json:"success"`
+	Error         *ResponseError  `json:"error,omitempty"`
+	Message       *string         `json:"message,omitempty"`
+	Ticket        *Ticket         `json:"ticket,omitempty"`
+	FileArtifacts *[]FileArtifact `json:"fileArtifacts,omitempty"`
 }
 
 // Makes ResponseError satisfy builtin Error type. See: https://blog.golang.org/error-handling-and-go

--- a/routes/get_artifact.go
+++ b/routes/get_artifact.go
@@ -1,0 +1,42 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/csci4950tgt/api/models"
+	"github.com/csci4950tgt/api/util"
+	"github.com/gorilla/mux"
+)
+
+func GetArtifact(w http.ResponseWriter, r *http.Request) {
+	// Get variables from route handler
+	vars := mux.Vars(r)                       // get dynamic variables from mux handler
+	ticketId, err := strconv.Atoi(vars["id"]) // get integer "id" from vars
+
+	if err != nil {
+		util.WriteHttpErrorCode(w, http.StatusBadRequest, "Missing required parameter: id.")
+
+		return
+	}
+
+	fileName := vars["fileName"]
+
+	// Fetch the file artifact:
+	fileArtifact, err := models.GetArtifact(uint(ticketId), fileName)
+
+	if err != nil {
+		msg := "Failed to get the file artifact."
+		util.WriteHttpErrorCode(w, http.StatusInternalServerError, msg)
+
+		fmt.Printf("An error occurred when fetching a file artifact with name %s and ticket ID %d:\n", fileName, ticketId)
+		fmt.Println(err)
+
+		return
+	}
+
+	// On success, send the file:
+	w.WriteHeader(http.StatusOK)
+	w.Write(fileArtifact.Data)
+}

--- a/routes/get_ticket_artifacts.go
+++ b/routes/get_ticket_artifacts.go
@@ -21,14 +21,30 @@ func GetTicketArtifacts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Get artifacts for ticket from database
+	// Make sure the ticket exists:
+	_, err = models.GetTicketById(uint(ticketId))
+
+	if err != nil {
+		msg := fmt.Sprintf("Failed to find ticket with ID %d.", ticketId)
+		util.WriteHttpErrorCode(w, http.StatusNotFound, msg)
+
+		return
+	}
+
+	// Fetch the list of matching file artifacts from the database:
+	fileArtifacts, err := models.GetAssociatedArtifacts(uint(ticketId))
+
+	if err != nil {
+		msg := "Failed to get a list of file artifacts associated with ticket."
+		util.WriteHttpErrorCode(w, http.StatusInternalServerError, msg)
+
+		return
+	}
 
 	// Initialize Response
-	msg := fmt.Sprintf("Not yet implemented... ticketId: %d", ticketId)
 	res := models.Response{
-		Success: true,
-		Message: &msg,
-		// TODO: add artifacts data to response
+		Success:       true,
+		FileArtifacts: fileArtifacts,
 	}
 
 	util.WriteHttpResponse(w, res)


### PR DESCRIPTION
Implements two endpoints to be used by the frontend - one to list all file artifacts associated with a ticket, and another to retrieve a particular file. Resolves #40 and resolves #43.

Listing artifacts:
```
➜  ~ curl -s localhost:8080/api/tickets/9/artifacts | prettyjson
{
    "fileArtifacts": [
        {
            "filename": "screenshot.png",
            "ticketID": 9
        },
        {
            "filename": "screenshotFull.png",
            "ticketID": 9
        }
    ],
    "success": true
}
```

Retrieving an artifact:
<img width="953" alt="Skärmavbild 2019-11-05 kl  1 23 17 fm" src="https://user-images.githubusercontent.com/1558223/68187094-5c803380-ff6b-11e9-8115-62673618adec.png">

It coincides well with making a progressbar if we want to download all resources, or a simple file browser if we want users to be able to select what they want to view. We could also base64 the contents itself right in the artifacts response, but that limits file size pretty quickly with a large overhead on the server and client.