### PR TITLE
Added functionality to GET /api/tickets endpoint. Fixes #39

### DIFF
--- a/models/response.go
+++ b/models/response.go
@@ -10,6 +10,7 @@ type Response struct {
 	Error         *ResponseError  `json:"error,omitempty"`
 	Message       *string         `json:"message,omitempty"`
 	Ticket        *Ticket         `json:"ticket,omitempty"`
+	Tickets       *[]Ticket       `json:"tickets,omitempty"`
 	FileArtifacts *[]FileArtifact `json:"fileArtifacts,omitempty"`
 }
 

--- a/models/ticket.go
+++ b/models/ticket.go
@@ -23,3 +23,10 @@ func GetTicketById(ID uint) (*Ticket, error) {
 
 	return &ticket, err
 }
+
+func GetTickets() (*[]Ticket, error) {
+	var tickets []Ticket
+	err := db.Find(&tickets).Error
+
+	return &tickets, err
+}

--- a/routes/get_tickets.go
+++ b/routes/get_tickets.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/csci4950tgt/api/models"
@@ -8,14 +9,24 @@ import (
 )
 
 func GetTickets(w http.ResponseWriter, r *http.Request) {
-	// TODO: Actually get all tickets
+	// get tickets from database
+	tickets, err := models.GetTickets()
+
+	// handle possible error
+	if err != nil {
+		msg := "Failed to fetch tickets from database."
+		util.WriteHttpErrorCode(w, http.StatusInternalServerError, msg)
+
+		fmt.Println(msg)
+		fmt.Println(err)
+
+		return
+	}
 
 	// Initialize Response
-	msg := "Not yet implemented!!"
 	res := models.Response{
 		Success: true,
-		Message: &msg,
-		// TODO: Return tickets in response
+		Tickets: tickets,
 	}
 
 	util.WriteHttpResponse(w, res)


### PR DESCRIPTION
Some other considerations:

- I think we should refactor the Response struct into multiple response types (ex: GetTicketsResponse), as a form of documentation to the frontend, and because errors could easily pop up by sending the wrong data to the frontend

- I also think we should eventually refactor this endpoint to return a range of tickets (limited to some number like 100), ordered by date_created and specified by the frontend. For example, the frontend could request the last 10 tickets, or tickets in the range of 30-40 last processed, etc