### PR TITLE
Google safe browsing support

### DIFF
--- a/models/response.go
+++ b/models/response.go
@@ -15,8 +15,9 @@ type Response struct {
 }
 
 type CreateTicketResponse struct {
-	Success       bool      `json: "success"`
-	FileArtifacts *[]string `json:"fileArtifacts"`
+	Success        bool      `json:"success"`
+	FileArtifacts  *[]string `json:"fileArtifacts"`
+	MalwareMatches string    `json:"malwareMatches"`
 }
 
 // Makes ResponseError satisfy builtin Error type. See: https://blog.golang.org/error-handling-and-go

--- a/models/ticket.go
+++ b/models/ticket.go
@@ -14,10 +14,11 @@ import (
 
 type Ticket struct {
 	gorm.Model
-	Name       string       `json:"name",gorm:"size:255"`
-	URL        string       `json:"url",gorm:"size:4096"`
-	Processed  bool         `json:"processed"`
-	ScreenShot []ScreenShot `json:"screenshots"`
+	Name           string       `json:"name",gorm:"size:255"`
+	URL            string       `json:"url",gorm:"size:4096"`
+	Processed      bool         `json:"processed"`
+	ScreenShot     []ScreenShot `json:"screenshots"`
+	MalwareMatches string       `json:"malwareMatches",gorm:"size:4096"`
 }
 
 // ProcessTicket saves processed ticket in database
@@ -45,6 +46,8 @@ func ProcessTicket(ticket *Ticket) {
 		log.Println("Error occured in honeyclient while processing ticket.")
 		return
 	}
+
+	db.Model(&ticket).Update("malwareMatches", body.MalwareMatches)
 
 	// Loop through file artifact string names, get each file artifact from in memory storage, save in DB
 	var fileArtifact FileArtifact


### PR DESCRIPTION
Add `MalwareMatches` to `type CreateTicketResponse struct` and `type Ticket struct`, write the results to the database (if any).

Currently, the results from Google safe browsing are stored as strings; when the frontend gets the string, it can be easily converted to a JS object.

See also https://github.com/csci4950tgt/honeyclient/pull/36